### PR TITLE
Detect and display producer key updates in schedule changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvoio/core-monitor",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Block Producer monitoring for Anvo Core and Legacy Antelope/EOSIO chains",
   "main": "dist/index.js",
   "scripts": {

--- a/src/alerting/AlertManager.ts
+++ b/src/alerting/AlertManager.ts
@@ -129,15 +129,40 @@ export class AlertManager {
     network: string;
     version: number;
     producers: string[];
+    added?: string[];
+    removed?: string[];
+    keyUpdates?: string[];
     blockNum: number;
     timestamp: string;
   }): Promise<void> {
+    const added = params.added || [];
+    const removed = params.removed || [];
+    const keyUpdates = params.keyUpdates || [];
+
+    // Build a descriptive title based on what actually changed
+    let title: string;
+    if (added.length === 0 && removed.length === 0 && keyUpdates.length > 0) {
+      title = `Schedule v${params.version} — key update`;
+    } else {
+      title = `Schedule change to v${params.version}`;
+    }
+
+    // Build a descriptive body
+    const lines: string[] = [];
+    lines.push(`Schedule v${params.version} (${params.producers.length} producers) at block ${params.blockNum}`);
+    if (added.length > 0) lines.push(`Added: ${added.join(', ')}`);
+    if (removed.length > 0) lines.push(`Removed: ${removed.join(', ')}`);
+    if (keyUpdates.length > 0) lines.push(`Key update: ${keyUpdates.join(', ')}`);
+    if (added.length === 0 && removed.length === 0 && keyUpdates.length === 0) {
+      lines.push(`Producers: ${params.producers.join(', ')}`);
+    }
+
     await this.sendAlert({
       severity: 'info',
       chain: params.chain,
       network: params.network,
-      title: `Schedule change to v${params.version}`,
-      body: `New schedule (${params.producers.length} producers) at block ${params.blockNum}\nProducers: ${params.producers.join(', ')}`,
+      title,
+      body: lines.join('\n'),
       timestamp: params.timestamp,
     });
   }

--- a/src/api/static/index.html
+++ b/src/api/static/index.html
@@ -335,7 +335,13 @@
         <div class="stat-card">
           <div class="label">Schedule</div>
           <div class="value mono">${esc(String(scheduleVersion))}${pending ? ' <span style="font-size:12px;color:var(--orange)">→ ' + esc(String(pending.version)) + ' proposed</span>' : ''}</div>
-          <div class="sub">${activation ? formatDate(activation.timestamp) + ' / block ' + (activation.blockNumber || 0).toLocaleString() : 'unknown activation'}${pending ? '<br>+' + esc((pending.added||[]).join(', ')) + (pending.removed?.length ? ' / -' + esc((pending.removed||[]).join(', ')) : '') : ''}</div>
+          <div class="sub">${activation ? formatDate(activation.timestamp) + ' / block ' + (activation.blockNumber || 0).toLocaleString() : 'unknown activation'}${pending ? '<br>' + (() => {
+            const parts = [];
+            if (pending.added?.length) parts.push('+' + esc(pending.added.join(', ')));
+            if (pending.removed?.length) parts.push('-' + esc(pending.removed.join(', ')));
+            if (pending.keyUpdates?.length) parts.push('key update: ' + esc(pending.keyUpdates.join(', ')));
+            return parts.join(' / ') || 'no producer changes';
+          })() : ''}</div>
         </div>
         <div class="stat-card">
           <div class="label">Current Round</div>
@@ -526,7 +532,18 @@
       const all = [
         ...missed.map(e => ({ severity: 'red', text: `${esc(e.producer)} missed ${e.blocks_missed} blocks`, time: e.timestamp })),
         ...forks.map(e => ({ severity: 'yellow', text: `Fork: ${esc(e.original_producer)} replaced by ${esc(e.replacement_producer)} at block ${e.block_number}`, time: e.timestamp })),
-        ...schedules.map(e => { try { return { severity: 'blue', text: `Schedule ${esc(String(e.schedule_version))} (${JSON.parse(e.producer_list).length} producers)`, time: e.timestamp }; } catch { return { severity: 'blue', text: `Schedule ${esc(String(e.schedule_version))}`, time: e.timestamp }; } }),
+        ...schedules.map(e => { try {
+          const count = JSON.parse(e.producer_list).length;
+          const added = e.producers_added ? JSON.parse(e.producers_added) : [];
+          const removed = e.producers_removed ? JSON.parse(e.producers_removed) : [];
+          const keyUpd = e.producers_key_updates ? JSON.parse(e.producers_key_updates) : [];
+          const parts = [];
+          if (added.length) parts.push('+' + esc(added.join(', ')));
+          if (removed.length) parts.push('-' + esc(removed.join(', ')));
+          if (keyUpd.length) parts.push('key update: ' + esc(keyUpd.join(', ')));
+          const detail = parts.length ? ' — ' + parts.join(' / ') : '';
+          return { severity: 'blue', text: `Schedule ${esc(String(e.schedule_version))} (${count} producers)${detail}`, time: e.timestamp };
+        } catch { return { severity: 'blue', text: `Schedule ${esc(String(e.schedule_version))}`, time: e.timestamp }; } }),
         ...producerEvents.map(e => {
           const label = e.action === 'regproducer' ? 'registered' : e.action === 'kickbp' ? 'kicked' : 'unregistered';
           const sev = e.action === 'regproducer' ? 'green' : e.action === 'kickbp' ? 'orange' : 'purple';

--- a/src/monitor/ChainMonitor.ts
+++ b/src/monitor/ChainMonitor.ts
@@ -224,19 +224,30 @@ export class ChainMonitor extends EventEmitter {
       this.pendingSchedule = block.new_producers;
       const pendingProducers = block.new_producers.producers.map((p) => p.producer_name);
       const currentProducers = this.schedule.producers;
+      const currentKeys = this.schedule.producerKeys;
       const added = pendingProducers.filter((p: string) => !currentProducers.includes(p));
       const removed = currentProducers.filter(p => !pendingProducers.includes(p));
+
+      // Detect key-only changes: same producer, different signing key
+      const keyUpdates: string[] = [];
+      for (const p of block.new_producers.producers) {
+        const oldKey = currentKeys[p.producer_name];
+        if (oldKey && oldKey !== p.block_signing_key && !added.includes(p.producer_name)) {
+          keyUpdates.push(p.producer_name);
+        }
+      }
 
       await this.db.setState(this.config.chain, this.config.network, 'pending_schedule', JSON.stringify({
         version: block.new_producers.version,
         producers: pendingProducers,
         added,
         removed,
+        keyUpdates,
         blockNum,
       }));
 
       this.log.info(
-        { version: block.new_producers.version, blockNum, added, removed },
+        { version: block.new_producers.version, blockNum, added, removed, keyUpdates: keyUpdates.length > 0 ? keyUpdates : undefined },
         'Pending schedule detected (not yet active)'
       );
     }
@@ -244,13 +255,13 @@ export class ChainMonitor extends EventEmitter {
     // The schedule_version in the block header tells us which schedule is
     // actually ACTIVE. When it increments, apply the pending schedule.
     if (block.schedule_version > this.schedule.version && this.pendingSchedule) {
-      const changed = await this.schedule.updateSchedule(
+      const result = await this.schedule.updateSchedule(
         this.pendingSchedule.version,
         this.pendingSchedule.producers,
         blockNum,
         block.timestamp
       );
-      if (changed) {
+      if (result) {
         await this.roundEvaluator.setScheduleActivation(block.timestamp);
 
         this.emit('schedule_change', {
@@ -258,6 +269,9 @@ export class ChainMonitor extends EventEmitter {
           network: this.config.network,
           version: this.pendingSchedule.version,
           producers: this.pendingSchedule.producers.map((p) => p.producer_name),
+          added: result.added,
+          removed: result.removed,
+          keyUpdates: result.keyUpdates,
           blockNum,
           timestamp: block.timestamp,
         });

--- a/src/monitor/ScheduleTracker.ts
+++ b/src/monitor/ScheduleTracker.ts
@@ -6,6 +6,7 @@ const log = logger.child({ module: 'ScheduleTracker' });
 export interface ProducerSchedule {
   version: number;
   producers: string[];
+  producerKeys?: Record<string, string>;
 }
 
 export class ScheduleTracker {
@@ -49,21 +50,39 @@ export class ScheduleTracker {
     return this.currentSchedule?.producers ?? [];
   }
 
+  get producerKeys(): Record<string, string> {
+    return this.currentSchedule?.producerKeys ?? {};
+  }
+
   async updateSchedule(
     version: number,
     producers: Array<{ producer_name: string; block_signing_key: string }>,
     blockNum: number,
     timestamp: string
-  ): Promise<boolean> {
+  ): Promise<false | { added: string[]; removed: string[]; keyUpdates: string[] }> {
     if (this.currentSchedule && version <= this.currentSchedule.version) {
       return false;
     }
 
     const newProducers = producers.map((p) => p.producer_name);
     const oldProducers = this.currentSchedule?.producers ?? [];
+    const oldKeys = this.currentSchedule?.producerKeys ?? {};
 
     const added = newProducers.filter((p) => !oldProducers.includes(p));
     const removed = oldProducers.filter((p) => !newProducers.includes(p));
+
+    // Detect key-only changes: same producer name, different signing key
+    const newKeys: Record<string, string> = {};
+    for (const p of producers) {
+      newKeys[p.producer_name] = p.block_signing_key;
+    }
+
+    const keyUpdates: string[] = [];
+    for (const p of newProducers) {
+      if (oldKeys[p] && newKeys[p] && oldKeys[p] !== newKeys[p] && !added.includes(p)) {
+        keyUpdates.push(p);
+      }
+    }
 
     log.info(
       {
@@ -74,11 +93,12 @@ export class ScheduleTracker {
         producerCount: newProducers.length,
         added: added.length > 0 ? added : undefined,
         removed: removed.length > 0 ? removed : undefined,
+        keyUpdates: keyUpdates.length > 0 ? keyUpdates : undefined,
       },
       'Schedule change detected'
     );
 
-    this.currentSchedule = { version, producers: newProducers };
+    this.currentSchedule = { version, producers: newProducers, producerKeys: newKeys };
 
     await this.db.setState(
       this.chain,
@@ -93,12 +113,13 @@ export class ScheduleTracker {
       schedule_version: version,
       producers_added: JSON.stringify(added),
       producers_removed: JSON.stringify(removed),
+      producers_key_updates: JSON.stringify(keyUpdates),
       producer_list: JSON.stringify(newProducers),
       block_number: blockNum,
       timestamp,
     });
 
-    return true;
+    return { added, removed, keyUpdates };
   }
 
   getProducerPosition(producer: string): number {

--- a/src/store/Database.ts
+++ b/src/store/Database.ts
@@ -266,7 +266,16 @@ export class Database {
         `);
       }
 
-      log.info({ version: 4 }, 'Database schema up to date');
+      if (currentVersion < 5) {
+        log.info('Running migration v5: add producers_key_updates column to schedule_changes');
+
+        await client.query(`
+          ALTER TABLE schedule_changes ADD COLUMN IF NOT EXISTS producers_key_updates TEXT;
+          INSERT INTO schema_version (version) VALUES (5);
+        `);
+      }
+
+      log.info({ version: 5 }, 'Database schema up to date');
     } finally {
       client.release();
     }
@@ -369,19 +378,20 @@ export class Database {
     schedule_version: number;
     producers_added: string;
     producers_removed: string;
+    producers_key_updates: string;
     producer_list: string;
     block_number: number;
     timestamp: string;
   }): Promise<void> {
     await this.pool.query(
       `INSERT INTO schedule_changes (chain, network, schedule_version,
-        producers_added, producers_removed, producer_list,
+        producers_added, producers_removed, producers_key_updates, producer_list,
         block_number, timestamp)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       ON CONFLICT (chain, network, schedule_version) DO NOTHING`,
       [params.chain, params.network, params.schedule_version,
-       params.producers_added, params.producers_removed, params.producer_list,
-       params.block_number, params.timestamp]
+       params.producers_added, params.producers_removed, params.producers_key_updates,
+       params.producer_list, params.block_number, params.timestamp]
     );
   }
 

--- a/tests/unit/schedule-tracker.test.ts
+++ b/tests/unit/schedule-tracker.test.ts
@@ -24,8 +24,8 @@ describe('ScheduleTracker', () => {
   });
 
   it('should accept initial schedule', async () => {
-    const changed = await tracker.updateSchedule(1, makeProducers(['bp1', 'bp2']), 1000, '2026-03-30T00:00:00.000');
-    expect(changed).toBe(true);
+    const result = await tracker.updateSchedule(1, makeProducers(['bp1', 'bp2']), 1000, '2026-03-30T00:00:00.000');
+    expect(result).toBeTruthy();
     expect(tracker.version).toBe(1);
     expect(tracker.producers).toEqual(['bp1', 'bp2']);
   });


### PR DESCRIPTION
## Summary

- Detects when a schedule version change is purely a signing key rotation (same producer set, different key) vs an actual producer set change
- Surfaces key updates in UI schedule card (`key update: cryptobloks`), events list, and alert messages
- Adds `producers_key_updates` column via DB migration v5
- Alert title differentiates: "Schedule v245 — key update" vs generic "Schedule change to v245"

## Changes

- **ScheduleTracker** — stores producer keys in state, compares old vs new to detect key rotations
- **ChainMonitor** — computes `keyUpdates` for pending and activated schedules, passes through events
- **AlertManager** — descriptive title/body based on what actually changed (added/removed/key update)
- **Database** — migration v5 adds `producers_key_updates` TEXT column to `schedule_changes`
- **UI (index.html)** — schedule stat card and events list show key update details
- **Tests** — updated `schedule-tracker.test.ts` assertion for new `updateSchedule` return type

## Test plan

- [ ] CI passes (TypeScript compile + unit tests)
- [ ] Verify on testnet with schedule 244 → 245 (cryptobloks key change) that UI shows "key update: cryptobloks"
- [ ] Verify alert message shows "Schedule v245 — key update" with "Key update: cryptobloks" in body
- [ ] Verify mixed changes (producer add + key update) show both correctly
- [ ] Verify DB migration v5 applies cleanly on existing database