### PR TITLE
Fix SHiP stall detection and multi-URL failover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anvoio/core-monitor",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anvoio/core-monitor",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/static": "^8.1.0",
@@ -2330,7 +2330,7 @@
       "license": "MIT"
     },
     "node_modules/real-require": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvoio/core-monitor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Block Producer monitoring for Anvo Core and Legacy Antelope/EOSIO chains",
   "main": "dist/index.js",
   "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export interface ChainConfig {
   chain: string;
   network: string;
   shipUrl: string;
-  shipFailoverUrl?: string;
+  shipFailoverUrls: string[];
   apiUrl: string;
   hyperionUrl?: string;
   chainId: string;
@@ -55,12 +55,17 @@ function parseChainConfig(id: string): ChainConfig {
   const prefix = id.toUpperCase().replace(/[^A-Z0-9]/g, '_');
   const [chain, network] = id.split('_');
 
+  const shipFailoverUrls = [
+    optionalEnv(`${prefix}_SHIP_FAILOVER_URL`),
+    optionalEnv(`${prefix}_CATCHUP_SHIP_URL`),
+  ].filter(Boolean);
+
   return {
     id,
     chain,
     network,
     shipUrl: requireEnv(`${prefix}_SHIP_URL`),
-    shipFailoverUrl: optionalEnv(`${prefix}_SHIP_FAILOVER_URL`) || undefined,
+    shipFailoverUrls,
     apiUrl: requireEnv(`${prefix}_API_URL`),
     hyperionUrl: optionalEnv(`${prefix}_HYPERION_URL`) || undefined,
     chainId: requireEnv(`${prefix}_CHAIN_ID`),

--- a/src/monitor/ChainMonitor.ts
+++ b/src/monitor/ChainMonitor.ts
@@ -49,7 +49,7 @@ export class ChainMonitor extends EventEmitter {
 
     this.ship = new ShipClient({
       url: this.config.shipUrl,
-      failoverUrl: this.config.shipFailoverUrl,
+      failoverUrls: this.config.shipFailoverUrls,
       startBlock,
       fetchBlock: true,
       fetchTraces: true,

--- a/src/ship/ShipClient.ts
+++ b/src/ship/ShipClient.ts
@@ -295,6 +295,9 @@ export class ShipClient extends EventEmitter {
   private state: ShipClientState = 'disconnected';
   private reconnectAttempts = 0;
   private reconnectTimer: NodeJS.Timeout | null = null;
+  private stallTimer: NodeJS.Timeout | null = null;
+  private urls: string[];
+  private urlIndex = 0;
   private currentUrl: string;
   private receivedAbi = false;
   private readonly maxInFlight = 10;
@@ -303,7 +306,7 @@ export class ShipClient extends EventEmitter {
     super();
     this.options = {
       url: options.url,
-      failoverUrl: options.failoverUrl || '',
+      failoverUrls: options.failoverUrls || [],
       startBlock: options.startBlock || 0,
       endBlock: options.endBlock || 0xffffffff,
       fetchBlock: options.fetchBlock !== false,
@@ -311,12 +314,45 @@ export class ShipClient extends EventEmitter {
       fetchDeltas: options.fetchDeltas || false,
       maxReconnectAttempts: options.maxReconnectAttempts || 100,
       reconnectDelayMs: options.reconnectDelayMs || 3000,
+      stallTimeoutMs: options.stallTimeoutMs || 30000,
     };
-    this.currentUrl = this.options.url;
+    this.urls = [this.options.url, ...this.options.failoverUrls];
+    this.currentUrl = this.urls[0];
   }
 
   get connectionState(): ShipClientState {
     return this.state;
+  }
+
+  private resetStallTimer(): void {
+    if (this.stallTimer) clearTimeout(this.stallTimer);
+    if (this.state !== 'streaming' && this.state !== 'connected') return;
+
+    this.stallTimer = setTimeout(() => {
+      log.warn(
+        { url: this.currentUrl, timeoutMs: this.options.stallTimeoutMs },
+        'SHiP stall detected — no data received, forcing reconnect'
+      );
+      this.forceReconnect();
+    }, this.options.stallTimeoutMs);
+  }
+
+  private clearStallTimer(): void {
+    if (this.stallTimer) {
+      clearTimeout(this.stallTimer);
+      this.stallTimer = null;
+    }
+  }
+
+  private forceReconnect(): void {
+    this.clearStallTimer();
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+    }
+    this.state = 'disconnected';
+    this.scheduleReconnect();
   }
 
   async connect(): Promise<void> {
@@ -336,10 +372,12 @@ export class ShipClient extends EventEmitter {
       this.ws.on('open', () => {
         log.info('SHiP WebSocket connected, waiting for ABI');
         this.reconnectAttempts = 0;
+        this.resetStallTimer();
         resolve();
       });
 
       this.ws.on('message', (data: ArrayBuffer | Buffer | string) => {
+        this.resetStallTimer();
         if (!this.receivedAbi) {
           this.handleAbiMessage(data);
         } else {
@@ -349,6 +387,7 @@ export class ShipClient extends EventEmitter {
 
       this.ws.on('close', (code, reason) => {
         log.warn({ code, reason: reason.toString() }, 'SHiP WebSocket closed');
+        this.clearStallTimer();
         this.state = 'disconnected';
         this.ws = null;
         this.scheduleReconnect();
@@ -407,6 +446,7 @@ export class ShipClient extends EventEmitter {
   }
 
   disconnect(): void {
+    this.clearStallTimer();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -738,13 +778,11 @@ export class ShipClient extends EventEmitter {
       return;
     }
 
-    // Toggle between primary and failover URL
-    if (this.options.failoverUrl && this.reconnectAttempts > 0 && this.reconnectAttempts % 3 === 0) {
-      this.currentUrl =
-        this.currentUrl === this.options.url
-          ? this.options.failoverUrl
-          : this.options.url;
-      log.info({ url: this.currentUrl }, 'Switching to failover SHiP endpoint');
+    // Cycle through URLs round-robin on each attempt
+    if (this.urls.length > 1) {
+      this.urlIndex = (this.urlIndex + 1) % this.urls.length;
+      this.currentUrl = this.urls[this.urlIndex];
+      log.info({ url: this.currentUrl, urlIndex: this.urlIndex }, 'Switching SHiP endpoint');
     }
 
     const delay = Math.min(

--- a/src/ship/types.ts
+++ b/src/ship/types.ts
@@ -80,7 +80,7 @@ export type ShipClientState = 'disconnected' | 'connecting' | 'connected' | 'str
 
 export interface ShipClientOptions {
   url: string;
-  failoverUrl?: string;
+  failoverUrls?: string[];
   startBlock?: number;
   endBlock?: number;
   fetchBlock?: boolean;
@@ -88,4 +88,6 @@ export interface ShipClientOptions {
   fetchDeltas?: boolean;
   maxReconnectAttempts?: number;
   reconnectDelayMs?: number;
+  /** Kill the connection if no message arrives within this many ms (default 30000) */
+  stallTimeoutMs?: number;
 }

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -70,7 +70,8 @@ async function main(): Promise<void> {
     monitor.on('fork', (params) => alertManager.fork(params));
 
     monitor.on('fatal', (err) => {
-      log.error({ err, chain: chainConfig.id }, 'Chain monitor fatal error');
+      log.error({ err, chain: chainConfig.id }, 'Chain monitor fatal error — exiting for restart');
+      process.exit(1);
     });
 
     try {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -19,6 +19,7 @@ describe('Config', () => {
     delete process.env.CHAINS;
     delete process.env.LIBRE_MAINNET_SHIP_URL;
     delete process.env.LIBRE_MAINNET_SHIP_FAILOVER_URL;
+    delete process.env.LIBRE_MAINNET_CATCHUP_SHIP_URL;
     delete process.env.LIBRE_MAINNET_API_URL;
     delete process.env.LIBRE_MAINNET_CHAIN_ID;
     delete process.env.LIBRE_MAINNET_SCHEDULE_SIZE;
@@ -80,7 +81,7 @@ describe('Config', () => {
     expect(config.chains[0].scheduleSize).toBe(21);
     expect(config.chains[0].blocksPerBp).toBe(12);
     expect(config.chains[0].blockTimeMs).toBe(500);
-    expect(config.chains[0].shipFailoverUrl).toBeUndefined();
+    expect(config.chains[0].shipFailoverUrls).toEqual([]);
     expect(config.chains[0].telegram).toBeUndefined();
   });
 
@@ -97,7 +98,7 @@ describe('Config', () => {
     expect(config.chains[0].scheduleSize).toBe(42);
     expect(config.chains[0].blocksPerBp).toBe(6);
     expect(config.chains[0].blockTimeMs).toBe(250);
-    expect(config.chains[0].shipFailoverUrl).toBe('wss://failover.example.com/');
+    expect(config.chains[0].shipFailoverUrls).toContain('wss://failover.example.com/');
   });
 
   it('should parse Telegram config when chat IDs are set', async () => {

--- a/tests/unit/ship-failover.test.ts
+++ b/tests/unit/ship-failover.test.ts
@@ -5,70 +5,63 @@ describe('ShipClient Failover', () => {
   it('should store primary and failover URLs', () => {
     const client = new ShipClient({
       url: 'wss://primary.example.com/',
-      failoverUrl: 'wss://failover.example.com/',
+      failoverUrls: ['wss://failover.example.com/'],
     });
 
-    // Verify initial URL is primary
     expect((client as any).currentUrl).toBe('wss://primary.example.com/');
-    expect((client as any).options.failoverUrl).toBe('wss://failover.example.com/');
+    expect((client as any).urls).toEqual([
+      'wss://primary.example.com/',
+      'wss://failover.example.com/',
+    ]);
   });
 
-  it('should toggle to failover URL every 3rd reconnect attempt', () => {
+  it('should cycle through URLs round-robin on reconnect', () => {
     const client = new ShipClient({
       url: 'wss://primary.example.com/',
-      failoverUrl: 'wss://failover.example.com/',
-      reconnectDelayMs: 1, // fast for testing
+      failoverUrls: [
+        'wss://failover.example.com/',
+        'ws://local.example.com:8080',
+      ],
+      reconnectDelayMs: 1,
     });
 
-    // Simulate reconnect attempts by calling scheduleReconnect
-    // Access private method via any
-    const scheduleReconnect = (client as any).scheduleReconnect.bind(client);
-
-    // Attempt 1 — stays on primary
-    (client as any).reconnectAttempts = 1;
+    // Initial URL is primary (index 0)
     expect((client as any).currentUrl).toBe('wss://primary.example.com/');
+    expect((client as any).urlIndex).toBe(0);
 
-    // Attempt 3 — should switch to failover
-    (client as any).reconnectAttempts = 3;
-    // The toggle happens inside scheduleReconnect when reconnectAttempts % 3 === 0
-    // Simulate the check
-    if ((client as any).options.failoverUrl && (client as any).reconnectAttempts % 3 === 0) {
-      (client as any).currentUrl = (client as any).options.failoverUrl;
-    }
+    // First reconnect -> index 1 (failover)
+    (client as any).scheduleReconnect();
     expect((client as any).currentUrl).toBe('wss://failover.example.com/');
+    expect((client as any).urlIndex).toBe(1);
 
-    // Attempt 6 — should switch back to primary
-    (client as any).reconnectAttempts = 6;
-    if ((client as any).options.failoverUrl && (client as any).reconnectAttempts % 3 === 0) {
-      (client as any).currentUrl = (client as any).currentUrl === (client as any).options.url
-        ? (client as any).options.failoverUrl
-        : (client as any).options.url;
-    }
+    // Second reconnect -> index 2 (local)
+    (client as any).scheduleReconnect();
+    expect((client as any).currentUrl).toBe('ws://local.example.com:8080');
+    expect((client as any).urlIndex).toBe(2);
+
+    // Third reconnect -> wraps to index 0 (primary)
+    (client as any).scheduleReconnect();
     expect((client as any).currentUrl).toBe('wss://primary.example.com/');
+    expect((client as any).urlIndex).toBe(0);
   });
 
-  it('should not attempt failover when no failover URL is configured', () => {
+  it('should not cycle URLs when only primary is configured', () => {
     const client = new ShipClient({
       url: 'wss://primary.example.com/',
     });
 
-    expect((client as any).options.failoverUrl).toBe('');
+    expect((client as any).urls).toEqual(['wss://primary.example.com/']);
     expect((client as any).currentUrl).toBe('wss://primary.example.com/');
 
-    // Even after many attempts, should stay on primary
-    (client as any).reconnectAttempts = 6;
-    // The condition checks failoverUrl exists first
-    if ((client as any).options.failoverUrl && (client as any).reconnectAttempts % 3 === 0) {
-      // This should NOT execute
-      (client as any).currentUrl = 'should-not-happen';
-    }
+    // After reconnect, should stay on primary
+    (client as any).scheduleReconnect();
     expect((client as any).currentUrl).toBe('wss://primary.example.com/');
   });
 
-  it('should reset reconnect attempts after successful connection', async () => {
+  it('should reset reconnect attempts after successful connection', () => {
     const client = new ShipClient({
       url: 'wss://primary.example.com/',
-      failoverUrl: 'wss://failover.example.com/',
+      failoverUrls: ['wss://failover.example.com/'],
     });
 
     (client as any).reconnectAttempts = 5;
@@ -84,7 +77,6 @@ describe('ShipClient Failover', () => {
       reconnectDelayMs: 3000,
     });
 
-    // Verify backoff formula: min(3000 * 2^min(attempt, 6), 60000)
     const calcDelay = (attempt: number) => Math.min(
       3000 * Math.pow(2, Math.min(attempt, 6)),
       60000
@@ -117,13 +109,13 @@ describe('ShipClient Failover', () => {
     expect(emitted).toBe(true);
   });
 
-  it('should clean up on disconnect', () => {
+  it('should clean up on disconnect including stall timer', () => {
     const client = new ShipClient({
       url: 'wss://primary.example.com/',
     });
 
-    // Set up some state
     (client as any).reconnectTimer = setTimeout(() => {}, 10000);
+    (client as any).stallTimer = setTimeout(() => {}, 10000);
     (client as any).state = 'connected';
 
     client.disconnect();
@@ -131,6 +123,7 @@ describe('ShipClient Failover', () => {
     expect((client as any).state).toBe('disconnected');
     expect((client as any).ws).toBeNull();
     expect((client as any).reconnectTimer).toBeNull();
+    expect((client as any).stallTimer).toBeNull();
   });
 
   it('should update startBlock for resume', () => {
@@ -143,5 +136,38 @@ describe('ShipClient Failover', () => {
 
     client.updateStartBlock(500);
     expect((client as any).options.startBlock).toBe(500);
+  });
+
+  it('should default stallTimeoutMs to 30000', () => {
+    const client = new ShipClient({
+      url: 'wss://primary.example.com/',
+    });
+
+    expect((client as any).options.stallTimeoutMs).toBe(30000);
+  });
+
+  it('should accept custom stallTimeoutMs', () => {
+    const client = new ShipClient({
+      url: 'wss://primary.example.com/',
+      stallTimeoutMs: 60000,
+    });
+
+    expect((client as any).options.stallTimeoutMs).toBe(60000);
+  });
+
+  it('should trigger forceReconnect on stall and cycle URL', () => {
+    const client = new ShipClient({
+      url: 'wss://primary.example.com/',
+      failoverUrls: ['wss://failover.example.com/'],
+      stallTimeoutMs: 100,
+    });
+
+    // Simulate stall detection triggering forceReconnect
+    (client as any).state = 'streaming';
+    (client as any).forceReconnect();
+
+    // Should be disconnected and URL should have cycled
+    expect((client as any).state).toBe('disconnected');
+    expect((client as any).currentUrl).toBe('wss://failover.example.com/');
   });
 });


### PR DESCRIPTION
## Summary
- **SHiP stall watchdog**: forces disconnect + reconnect if no WebSocket message arrives within 30s (configurable `stallTimeoutMs`), preventing silent connection stalls from going undetected
- **Multi-URL failover**: replaces single `failoverUrl` with `failoverUrls` array, cycling round-robin through primary, remote failover, and local SHiP endpoints on each reconnect attempt
- **Exit on fatal**: writer now calls `process.exit(1)` on chain monitor fatal errors so Docker's `restart: unless-stopped` can recover as a last resort

## Context
The writer stopped processing blocks for ~3 days (April 8-11) because both SHiP WebSocket connections silently stalled — the TCP connection stayed open but no data arrived. Since no `close` event fired, the reconnect logic never triggered, and neither the failover endpoints nor the local SHiP servers were ever tried. The process stayed alive running only cron jobs (hourly reconciliation, daily retention).

## Test plan
- [x] TypeScript compiles cleanly
- [x] All unit tests pass (config, ship-failover — 11 tests including new stall/round-robin tests)
- [x] Writer restarted on hydra and confirmed catching up on both chains
- [ ] Deploy updated image to hydra and verify stall detection triggers failover in logs