### PR TITLE
Read footer version from package.json

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,7 +1,10 @@
 import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
 import path from 'path';
+import { readFileSync } from 'fs';
 import { logger } from '../utils/logger.js';
+
+const { version } = JSON.parse(readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'));
 import { healthRoutes } from './routes/health.js';
 import { chainRoutes } from './routes/chains.js';
 import { producerRoutes } from './routes/producers.js';
@@ -51,9 +54,18 @@ export async function createServer(config: AppConfig, db: Database) {
 
   // Serve static dashboard files
   const staticDir = path.resolve(__dirname, 'static');
+
+  // Serve index.html with version from package.json
+  const indexHtml = readFileSync(path.join(staticDir, 'index.html'), 'utf8')
+    .replace('{{VERSION}}', version);
+  app.get('/', async (_request, reply) => {
+    reply.type('text/html').send(indexHtml);
+  });
+
   await app.register(fastifyStatic, {
     root: staticDir,
     prefix: '/',
+    index: false,
   });
 
   // Register API routes

--- a/src/api/static/index.html
+++ b/src/api/static/index.html
@@ -196,7 +196,7 @@
   <footer>
     &copy; 2026 <a href="https://anvo.io">AnvoIO</a> &mdash;
     <a href="https://github.com/AnvoIO/core-monitor">AnvoIO/core-monitor</a>
-    <span style="margin-left:8px">v0.2.1</span>
+    <span style="margin-left:8px">v{{VERSION}}</span>
   </footer>
 
   <script>


### PR DESCRIPTION
Eliminates the hardcoded version in index.html. Server reads it from package.json at startup and injects it via template placeholder.