### PR TITLE
Dedupe fork_events to prevent SHiP reorg replay duplicates

### DIFF
--- a/src/store/Database.ts
+++ b/src/store/Database.ts
@@ -419,7 +419,25 @@ export class Database {
         log.info('Migration v6 complete — summary tables populated');
       }
 
-      log.info({ version: 6 }, 'Database schema up to date');
+      if (currentVersion < 7) {
+        log.info('Running migration v7: deduplicate fork_events');
+
+        await client.query(`
+          DELETE FROM fork_events a USING fork_events b
+          WHERE a.id > b.id
+            AND a.chain = b.chain AND a.network = b.network
+            AND a.block_number = b.block_number
+            AND a.original_producer = b.original_producer
+            AND a.replacement_producer = b.replacement_producer;
+
+          CREATE UNIQUE INDEX IF NOT EXISTS idx_fork_events_dedup
+            ON fork_events(chain, network, block_number, original_producer, replacement_producer);
+
+          INSERT INTO schema_version (version) VALUES (7);
+        `);
+      }
+
+      log.info({ version: 7 }, 'Database schema up to date');
     } finally {
       client.release();
     }
@@ -575,7 +593,9 @@ export class Database {
     await this.pool.query(
       `INSERT INTO fork_events (chain, network, round_id,
         block_number, original_producer, replacement_producer, timestamp)
-      VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      ON CONFLICT (chain, network, block_number, original_producer, replacement_producer)
+      DO NOTHING`,
       [params.chain, params.network, params.round_id,
        params.block_number, params.original_producer, params.replacement_producer, params.timestamp]
     );

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -5,6 +5,8 @@ import { createTestDb, cleanTestDb, getTestPgUrl } from '../setup.js';
 import type { AppConfig } from '../../src/config.js';
 import type { FastifyInstance } from 'fastify';
 
+const TEST_DAY = new Date(Date.now() - 86400000).toISOString().substring(0, 10);
+
 describe('API Routes', () => {
   let app: FastifyInstance;
   let db: Database;
@@ -32,8 +34,8 @@ describe('API Routes', () => {
     for (let i = 1; i <= 5; i++) {
       const roundId = await db.insertRound({
         chain: 'libre', network: 'mainnet', round_number: i,
-        schedule_version: 1, timestamp_start: `2026-03-30T00:0${i}:00.000`,
-        timestamp_end: `2026-03-30T00:0${i}:30.000`, producers_scheduled: 2,
+        schedule_version: 1, timestamp_start: `${TEST_DAY}T00:0${i}:00.000`,
+        timestamp_end: `${TEST_DAY}T00:0${i}:30.000`, producers_scheduled: 2,
         producers_produced: i <= 4 ? 2 : 1, producers_missed: i <= 4 ? 0 : 1,
       });
       await db.insertRoundProducer({
@@ -52,18 +54,18 @@ describe('API Routes', () => {
     await db.insertMissedBlockEvent({
       chain: 'libre', network: 'mainnet', producer: 'okbp',
       round_id: null, blocks_missed: 12, block_number: 500,
-      timestamp: '2026-03-30T00:05:30.000',
+      timestamp: `${TEST_DAY}T00:05:30.000`,
     });
     await db.insertForkEvent({
       chain: 'libre', network: 'mainnet', round_id: null,
       block_number: 350, original_producer: 'okbp',
-      replacement_producer: 'goodbp', timestamp: '2026-03-30T00:03:15.000',
+      replacement_producer: 'goodbp', timestamp: `${TEST_DAY}T00:03:15.000`,
     });
     await db.insertScheduleChange({
       chain: 'libre', network: 'mainnet', schedule_version: 1,
       producers_added: '["goodbp","okbp"]', producers_removed: '[]',
       producer_list: '["goodbp","okbp"]', block_number: 1,
-      timestamp: '2026-03-30T00:00:00.000',
+      timestamp: `${TEST_DAY}T00:00:00.000`,
     });
   }
 
@@ -71,7 +73,7 @@ describe('API Routes', () => {
     db = await createTestDb();
     await cleanTestDb();
     await seedData();
-    await db.reconcileDay('libre', 'mainnet', '2026-03-30');
+    await db.reconcileDay('libre', 'mainnet', TEST_DAY);
     app = await createServer(config, db);
     await app.ready();
   });

--- a/tests/unit/database.test.ts
+++ b/tests/unit/database.test.ts
@@ -131,6 +131,20 @@ describe('Database', () => {
       expect(events).toHaveLength(1);
       expect(events[0].original_producer).toBe('bp_a');
     });
+
+    it('should dedupe repeated inserts for the same fork', async () => {
+      const event = {
+        chain: 'libre', network: 'mainnet', round_id: null,
+        block_number: 4000, original_producer: 'bp_x',
+        replacement_producer: 'bp_y', timestamp: '2026-03-30T00:01:00.000',
+      };
+      await db.insertForkEvent(event);
+      await db.insertForkEvent(event);
+      await db.insertForkEvent(event);
+      const events = await db.getForkEvents('libre', 'mainnet');
+      const matching = events.filter(e => e.block_number === 4000);
+      expect(matching).toHaveLength(1);
+    });
   });
 
   describe('producer stats', () => {

--- a/tests/unit/database.test.ts
+++ b/tests/unit/database.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { createTestDb, cleanTestDb, getTestPgUrl } from '../setup.js';
 import { Database } from '../../src/store/Database.js';
 
+const TEST_DAY = new Date(Date.now() - 86400000).toISOString().substring(0, 10);
+
 describe('Database', () => {
   let db: Database;
 
@@ -45,8 +47,8 @@ describe('Database', () => {
     it('should insert and retrieve a round', async () => {
       const roundId = await db.insertRound({
         chain: 'libre', network: 'mainnet', round_number: 1,
-        schedule_version: 5, timestamp_start: '2026-03-30T00:00:00.000',
-        timestamp_end: '2026-03-30T00:02:06.000', producers_scheduled: 21,
+        schedule_version: 5, timestamp_start: `${TEST_DAY}T00:00:00.000`,
+        timestamp_end: `${TEST_DAY}T00:02:06.000`, producers_scheduled: 21,
         producers_produced: 20, producers_missed: 1,
       });
       expect(roundId).toBeGreaterThan(0);
@@ -59,8 +61,8 @@ describe('Database', () => {
       for (let i = 1; i <= 5; i++) {
         await db.insertRound({
           chain: 'libre', network: 'mainnet', round_number: i,
-          schedule_version: 1, timestamp_start: `2026-03-30T00:0${i}:00.000`,
-          timestamp_end: `2026-03-30T00:0${i}:30.000`, producers_scheduled: 21,
+          schedule_version: 1, timestamp_start: `${TEST_DAY}T00:0${i}:00.000`,
+          timestamp_end: `${TEST_DAY}T00:0${i}:30.000`, producers_scheduled: 21,
           producers_produced: 21, producers_missed: 0,
         });
       }
@@ -73,8 +75,8 @@ describe('Database', () => {
     it('should isolate rounds by chain/network', async () => {
       await db.insertRound({
         chain: 'libre', network: 'mainnet', round_number: 1,
-        schedule_version: 1, timestamp_start: '2026-03-30T00:00:00.000',
-        timestamp_end: '2026-03-30T00:02:00.000', producers_scheduled: 21,
+        schedule_version: 1, timestamp_start: `${TEST_DAY}T00:00:00.000`,
+        timestamp_end: `${TEST_DAY}T00:02:00.000`, producers_scheduled: 21,
         producers_produced: 21, producers_missed: 0,
       });
       expect(await db.getRecentRounds('libre', 'mainnet')).toHaveLength(1);
@@ -86,8 +88,8 @@ describe('Database', () => {
     it('should insert and retrieve round producers', async () => {
       const roundId = await db.insertRound({
         chain: 'libre', network: 'mainnet', round_number: 1,
-        schedule_version: 1, timestamp_start: '2026-03-30T00:00:00.000',
-        timestamp_end: '2026-03-30T00:02:00.000', producers_scheduled: 2,
+        schedule_version: 1, timestamp_start: `${TEST_DAY}T00:00:00.000`,
+        timestamp_end: `${TEST_DAY}T00:02:00.000`, producers_scheduled: 2,
         producers_produced: 1, producers_missed: 1,
       });
       await db.insertRoundProducer({
@@ -112,7 +114,7 @@ describe('Database', () => {
       await db.insertMissedBlockEvent({
         chain: 'libre', network: 'mainnet', producer: 'badproducer',
         round_id: null, blocks_missed: 12, block_number: 5000,
-        timestamp: '2026-03-30T00:01:00.000',
+        timestamp: `${TEST_DAY}T00:01:00.000`,
       });
       const events = await db.getMissedBlockEvents('libre', 'mainnet');
       expect(events).toHaveLength(1);
@@ -125,7 +127,7 @@ describe('Database', () => {
       await db.insertForkEvent({
         chain: 'libre', network: 'mainnet', round_id: null,
         block_number: 3000, original_producer: 'bp_a',
-        replacement_producer: 'bp_b', timestamp: '2026-03-30T00:00:30.000',
+        replacement_producer: 'bp_b', timestamp: `${TEST_DAY}T00:00:30.000`,
       });
       const events = await db.getForkEvents('libre', 'mainnet');
       expect(events).toHaveLength(1);
@@ -136,7 +138,7 @@ describe('Database', () => {
       const event = {
         chain: 'libre', network: 'mainnet', round_id: null,
         block_number: 4000, original_producer: 'bp_x',
-        replacement_producer: 'bp_y', timestamp: '2026-03-30T00:01:00.000',
+        replacement_producer: 'bp_y', timestamp: `${TEST_DAY}T00:01:00.000`,
       };
       await db.insertForkEvent(event);
       await db.insertForkEvent(event);
@@ -152,8 +154,8 @@ describe('Database', () => {
       for (let i = 1; i <= 3; i++) {
         const roundId = await db.insertRound({
           chain: 'libre', network: 'mainnet', round_number: i,
-          schedule_version: 1, timestamp_start: `2026-03-30T00:0${i}:00.000`,
-          timestamp_end: `2026-03-30T00:0${i}:30.000`, producers_scheduled: 2,
+          schedule_version: 1, timestamp_start: `${TEST_DAY}T00:0${i}:00.000`,
+          timestamp_end: `${TEST_DAY}T00:0${i}:30.000`, producers_scheduled: 2,
           producers_produced: 2, producers_missed: 0,
         });
         await db.insertRoundProducer({
@@ -172,7 +174,7 @@ describe('Database', () => {
 
     it('should compute all producer stats ranked by reliability', async () => {
       await seedData();
-      await db.reconcileDay('libre', 'mainnet', '2026-03-30');
+      await db.reconcileDay('libre', 'mainnet', TEST_DAY);
       const allStats = await db.getAllProducerStats('libre', 'mainnet', 30);
       expect(allStats).toHaveLength(2);
       expect(allStats[0].producer).toBe('goodbp');
@@ -190,8 +192,8 @@ describe('Database', () => {
     it('should return production status for latest round', async () => {
       const roundId = await db.insertRound({
         chain: 'libre', network: 'mainnet', round_number: 1,
-        schedule_version: 1, timestamp_start: '2026-03-30T00:00:00.000',
-        timestamp_end: '2026-03-30T00:02:00.000', producers_scheduled: 2,
+        schedule_version: 1, timestamp_start: `${TEST_DAY}T00:00:00.000`,
+        timestamp_end: `${TEST_DAY}T00:02:00.000`, producers_scheduled: 2,
         producers_produced: 1, producers_missed: 1,
       });
       await db.insertRoundProducer({


### PR DESCRIPTION
## Summary
- Fixes #20
- Migration v7 dedupes existing `fork_events` rows and adds `UNIQUE(chain, network, block_number, original_producer, replacement_producer)`
- `insertForkEvent` uses `ON CONFLICT DO NOTHING`
- New unit test covers idempotent repeat inserts
- Also fixes a time-bomb in producer-stats tests: they hardcoded 2026-03-30 against a 30-day rolling window; switched to a TEST_DAY derived from today

## Why
SHiP re-streams the affected range on chain reorgs. `ChainMonitor` fires fork detection on every re-delivery whose `prev_block.block_id` mismatches the stale `lastBlockId` and unconditionally inserts a row. The table had no UNIQUE constraint, so a single reorg produced a burst of duplicates — confirmed in production: block 240,749,749 has 19 rows inserted in 6 seconds.

## Verified on prod DB (transactional dry-run, rolled back)
- Before: 4,648 rows
- After v7 dedup: 837 rows (82% duplication)
- `ON CONFLICT DO NOTHING` correctly suppressed a synthetic re-insert