### PR TITLE
Add CATCHUP_END_BLOCK override for recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,11 @@ RETENTION_DAYS=548
 # LIBRE_TESTNET_CATCHUP_SHIP_URL=ws://history-node:8087
 # Start block (default: 1 for genesis)
 # CATCHUP_START_BLOCK=1
+# Stop block (default: live writer's current position). Set during recovery
+# to let catchup outpace a far-behind live writer. Per-chain or global:
+# CATCHUP_END_BLOCK=248000000
+# LIBRE_MAINNET_CATCHUP_END_BLOCK=248000000
+# LIBRE_TESTNET_CATCHUP_END_BLOCK=245000000
 
 # ============================================================================
 # Logging

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Thumbs.db
 # IDE
 .vscode/
 .idea/
+.claude/

--- a/src/catchup-writer.ts
+++ b/src/catchup-writer.ts
@@ -11,6 +11,9 @@
  * Environment:
  *   CATCHUP_SHIP_URL — SHiP endpoint for full history node (required)
  *   CATCHUP_START_BLOCK — start block (default: 1)
+ *   CATCHUP_END_BLOCK — optional override; stop at this block instead of the
+ *     live writer's position. Per-chain form: {CHAIN_ID}_CATCHUP_END_BLOCK.
+ *     Use during recovery to let catchup outpace a far-behind live writer.
  *   POSTGRES_URL — PostgreSQL connection string (required)
  *   CHAINS — chain config (same as live writer)
  */
@@ -80,7 +83,17 @@ async function startCatchup(chainConfig: ChainConfig, db: Database): Promise<voi
   }
 
   const configStartBlock = parseInt(process.env.CATCHUP_START_BLOCK || '1', 10);
-  const endBlock = await findLiveWriterStartBlock(db, chainConfig.chain, chainConfig.network);
+
+  // Optional override: chase a specific block instead of stopping at the live
+  // writer's position. Used during recovery when the writer is far behind and
+  // we want catchup (3000+ bps) to fill the gap instead of waiting for the
+  // writer (~100 bps) to grind through it.
+  const chainPrefix = chainConfig.id.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+  const endBlockOverrideStr = process.env[`${chainPrefix}_CATCHUP_END_BLOCK`]
+    || process.env.CATCHUP_END_BLOCK;
+  const endBlock = endBlockOverrideStr
+    ? parseInt(endBlockOverrideStr, 10)
+    : await findLiveWriterStartBlock(db, chainConfig.chain, chainConfig.network);
 
   // Resume from last processed block if available
   const savedBlock = await db.getState(chainConfig.chain, chainConfig.network, 'catchup_last_block');


### PR DESCRIPTION
## Summary
Adds an optional `CATCHUP_END_BLOCK` (or per-chain `{CHAIN_ID}_CATCHUP_END_BLOCK`) env var that overrides the catchup writer's normal stop point.

## Why
Catchup writer normally stops where the live writer is currently positioned (`findLiveWriterStartBlock`). During recovery the live writer is millions of blocks behind chain head and processing at ~100 bps. With this override, catchup (which runs ~3,300 bps thanks to batched writes) can chase chain head and close a 7M block gap in ~30 minutes instead of ~20 hours.

## Operational use
1. Stop the live writer
2. Set `LIBRE_MAINNET_CATCHUP_END_BLOCK` and `LIBRE_TESTNET_CATCHUP_END_BLOCK` in `.env`
3. Recreate the catchup container
4. After catchup finishes, bump live writer's `last_block` state to the end-block and start it back up