### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anvoio/core-monitor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anvoio/core-monitor",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/static": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvoio/core-monitor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Block Producer monitoring for Anvo Core and Legacy Antelope/EOSIO chains",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Should have gone in with the dev → main merge in #23 but was missed. Covers PRs #21 (fork_events dedup) and #22 (catchup end-block override).