### PR TITLE
Dedupe missed_block_events and stop orphan inserts on round dupe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anvoio/core-monitor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anvoio/core-monitor",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@fastify/static": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvoio/core-monitor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Block Producer monitoring for Anvo Core and Legacy Antelope/EOSIO chains",
   "main": "dist/index.js",
   "scripts": {

--- a/src/monitor/RoundEvaluator.ts
+++ b/src/monitor/RoundEvaluator.ts
@@ -338,6 +338,11 @@ export class RoundEvaluator {
       producers_missed: result.producersMissed,
     });
 
+    // Round was a duplicate (e.g. SHiP replay or restart over already-processed
+    // range) — skip all dependent inserts so we don't create orphan rows or
+    // double-count daily stats. Matches persistRoundBatch behavior.
+    if (roundId === null) return;
+
     const day = result.timestampStart.substring(0, 10);
 
     for (const pr of result.producerResults) {

--- a/src/store/Database.ts
+++ b/src/store/Database.ts
@@ -437,7 +437,29 @@ export class Database {
         `);
       }
 
-      log.info({ version: 7 }, 'Database schema up to date');
+      if (currentVersion < 8) {
+        log.info('Running migration v8: deduplicate missed_block_events');
+
+        // Drop orphan rows (round_id NULL) left by the live writer reprocessing
+        // a duplicate round before the persistRoundIndividual skip was added.
+        // Then dedupe surviving rows by (round_id, producer) — natural key for
+        // a producer's miss in a specific round.
+        await client.query(`
+          DELETE FROM missed_block_events WHERE round_id IS NULL;
+
+          DELETE FROM missed_block_events a USING missed_block_events b
+          WHERE a.id > b.id
+            AND a.round_id = b.round_id
+            AND a.producer = b.producer;
+
+          CREATE UNIQUE INDEX IF NOT EXISTS idx_missed_events_dedup
+            ON missed_block_events(round_id, producer);
+
+          INSERT INTO schema_version (version) VALUES (8);
+        `);
+      }
+
+      log.info({ version: 8 }, 'Database schema up to date');
     } finally {
       client.release();
     }
@@ -504,10 +526,12 @@ export class Database {
     block_number: number | null;
     timestamp: string;
   }): Promise<void> {
+    if (params.round_id === null) return; // round was a duplicate, skip
     await this.pool.query(
       `INSERT INTO missed_block_events (chain, network, producer,
         round_id, blocks_missed, block_number, timestamp)
-      VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      ON CONFLICT (round_id, producer) DO NOTHING`,
       [params.chain, params.network, params.producer,
        params.round_id, params.blocks_missed, params.block_number, params.timestamp]
     );
@@ -560,12 +584,15 @@ export class Database {
     }>,
     client?: pg.PoolClient
   ): Promise<void> {
-    if (rows.length === 0) return;
+    // Skip rows without round_id — the round was a duplicate so we shouldn't
+    // emit orphan missed events. The unique index requires non-null round_id.
+    const valid = rows.filter(r => r.round_id !== null);
+    if (valid.length === 0) return;
     const cols = 7;
     const values: any[] = [];
     const placeholders: string[] = [];
-    for (let i = 0; i < rows.length; i++) {
-      const r = rows[i];
+    for (let i = 0; i < valid.length; i++) {
+      const r = valid[i];
       const b = i * cols;
       placeholders.push(`($${b+1},$${b+2},$${b+3},$${b+4},$${b+5},$${b+6},$${b+7})`);
       values.push(r.chain, r.network, r.producer, r.round_id, r.blocks_missed, r.block_number, r.timestamp);
@@ -574,7 +601,8 @@ export class Database {
     await q.query(
       `INSERT INTO missed_block_events (chain, network, producer,
         round_id, blocks_missed, block_number, timestamp)
-      VALUES ${placeholders.join(',')}`,
+      VALUES ${placeholders.join(',')}
+      ON CONFLICT (round_id, producer) DO NOTHING`,
       values
     );
   }

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -31,6 +31,7 @@ describe('API Routes', () => {
   };
 
   async function seedData() {
+    let missedRoundId: number | null = null;
     for (let i = 1; i <= 5; i++) {
       const roundId = await db.insertRound({
         chain: 'libre', network: 'mainnet', round_number: i,
@@ -38,6 +39,7 @@ describe('API Routes', () => {
         timestamp_end: `${TEST_DAY}T00:0${i}:30.000`, producers_scheduled: 2,
         producers_produced: i <= 4 ? 2 : 1, producers_missed: i <= 4 ? 0 : 1,
       });
+      if (i === 5) missedRoundId = roundId;
       await db.insertRoundProducer({
         round_id: roundId, producer: 'goodbp', position: 0,
         blocks_expected: 12, blocks_produced: 12, blocks_missed: 0,
@@ -53,7 +55,7 @@ describe('API Routes', () => {
     }
     await db.insertMissedBlockEvent({
       chain: 'libre', network: 'mainnet', producer: 'okbp',
-      round_id: null, blocks_missed: 12, block_number: 500,
+      round_id: missedRoundId, blocks_missed: 12, block_number: 500,
       timestamp: `${TEST_DAY}T00:05:30.000`,
     });
     await db.insertForkEvent({

--- a/tests/unit/database.test.ts
+++ b/tests/unit/database.test.ts
@@ -110,15 +110,49 @@ describe('Database', () => {
   });
 
   describe('missed_block_events', () => {
+    async function seedRound() {
+      return await db.insertRound({
+        chain: 'libre', network: 'mainnet', round_number: 1,
+        schedule_version: 1, timestamp_start: `${TEST_DAY}T00:00:00.000`,
+        timestamp_end: `${TEST_DAY}T00:02:00.000`, producers_scheduled: 1,
+        producers_produced: 0, producers_missed: 1,
+      });
+    }
+
     it('should insert and retrieve missed block events', async () => {
+      const roundId = await seedRound();
+      await db.insertMissedBlockEvent({
+        chain: 'libre', network: 'mainnet', producer: 'badproducer',
+        round_id: roundId, blocks_missed: 12, block_number: 5000,
+        timestamp: `${TEST_DAY}T00:01:00.000`,
+      });
+      const events = await db.getMissedBlockEvents('libre', 'mainnet');
+      expect(events).toHaveLength(1);
+      expect(events[0].producer).toBe('badproducer');
+    });
+
+    it('should skip insert when round_id is null (orphan prevention)', async () => {
       await db.insertMissedBlockEvent({
         chain: 'libre', network: 'mainnet', producer: 'badproducer',
         round_id: null, blocks_missed: 12, block_number: 5000,
         timestamp: `${TEST_DAY}T00:01:00.000`,
       });
       const events = await db.getMissedBlockEvents('libre', 'mainnet');
+      expect(events).toHaveLength(0);
+    });
+
+    it('should dedupe repeated inserts for the same (round, producer)', async () => {
+      const roundId = await seedRound();
+      const event = {
+        chain: 'libre', network: 'mainnet', producer: 'badproducer',
+        round_id: roundId, blocks_missed: 12, block_number: 5000,
+        timestamp: `${TEST_DAY}T00:01:00.000`,
+      };
+      await db.insertMissedBlockEvent(event);
+      await db.insertMissedBlockEvent(event);
+      await db.insertMissedBlockEvent(event);
+      const events = await db.getMissedBlockEvents('libre', 'mainnet');
       expect(events).toHaveLength(1);
-      expect(events[0].producer).toBe('badproducer');
     });
   });
 


### PR DESCRIPTION
## Summary
Stops missed_block_events from accumulating duplicate or orphan rows when the same range is reprocessed (SHiP replay, writer restart over already-stored blocks).

## Changes
- `persistRoundIndividual` returns early when insertRound's ON CONFLICT produces a null roundId, matching the catchup writer's `persistRoundBatch`. Stops inserting missed events with round_id=null, double-upserting producer_stats_daily, and double-tracking outage streaks.
- `insertMissedBlockEvent` / `insertMissedBlockEventsBatch` skip null-round_id rows and use `ON CONFLICT (round_id, producer) DO NOTHING`.
- Migration v8 deletes legacy NULL-round_id orphan rows and adds `UNIQUE INDEX idx_missed_events_dedup ON missed_block_events(round_id, producer)`.

## Verified on prod DB (dry-run, rolled back)
- Total rows: 312,329
- NULL-round_id orphans: 42 (deleted)
- Non-orphan dupes: 0
- UNIQUE index created cleanly

## Tests
- Existing missed_block_events insert/retrieve test updated to seed a real round
- New test: skip when round_id is null
- New test: idempotent repeat inserts collapse to one row